### PR TITLE
chore: add Dockerfile for containerized usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+tests/
+*.egg-info/
+.venv/
+venv/
+dist/
+build/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir .
+
+# mcptoon is a CLI the agent shells out to; make the subcommand pass-through
+# so `docker run mcptoon manifest --toon` works the same as `mcptoon manifest --toon`.
+ENTRYPOINT ["mcptoon"]
+CMD ["help"]

--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ mcptoon manifest --slim               # → tool schemas, 93% smaller than JSON
 mcptoon call fetch fetch '{"url":"https://example.com"}' --toon
 ```
 
+## Docker
+
+mcptoon is zero-dependency, so the image is small. Build it and run any subcommand. The entrypoint is `mcptoon`, so args pass through exactly as on the host:
+
+```bash
+docker build -t mcptoon .
+docker run --rm mcptoon help
+docker run --rm mcptoon manifest --toon
+```
+
+Server config lives at `~/.mcptoon/config.json` on the host. Mount it so the container shares your servers:
+
+```bash
+docker run --rm -v ~/.mcptoon:/root/.mcptoon mcptoon manifest --toon
+```
+
+`manifest`, `list`, `inspect`, and `doctor` are config-only and work out of the box. `call` and `add --stdio` spawn a server process (for example `npx`), so they need that runtime available inside the image: extend the Dockerfile with the toolchain your servers require.
+
 ## Works with every agent
 
 mcptoon is a CLI tool. **If your agent can run shell commands, it can use mcptoon.** No plugins. No SDK. No per-agent MCP setup. No JSON config editing.


### PR DESCRIPTION
## What

Adds a `Dockerfile` + `.dockerignore` so mcptoon can run containerized, plus a short Docker section in the README.

Closes #7.

## Why

mcptoon is a zero-dependency CLI, so the image is small and the entrypoint passes subcommands straight through (`docker run mcptoon manifest --toon` works the same as `mcptoon manifest --toon`). Server config lives at `~/.mcptoon/config.json`, so the README shows the volume mount that shares it with the host.

## Verification

- `docker build -t mcptoon .` succeeds.
- `docker run --rm mcptoon help` prints the usage (default `CMD`).
- `docker run --rm mcptoon manifest --toon` passes the subcommand through the entrypoint and runs (returns "No tools found" with no config mounted, as expected).

## Notes

`manifest` / `list` / `inspect` / `doctor` are config-only and work out of the box. `call` and `add --stdio` spawn a server process (for example `npx`), so the README notes the image may need extending with that toolchain.
