### PR TITLE
docs: add optional Parallel Search install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,18 @@ mcptoon install my-tool --pip mcp-my-tool
 # HTTP/SSE server:
 mcptoon install remote-api --url https://example.com/mcp
 
+# Parallel Search (optional; no account or API key required):
+mcptoon install parallel-search --url https://search.parallel.ai/mcp
+
 # List what you have:
 mcptoon install --list
 
 # Remove:
 mcptoon install --remove brave-search
 ```
+
+When you explicitly use Parallel Search, user-provided search objectives, search queries, and
+requested URLs are sent to Parallel.
 
 mcptoon auto-connects, discovers tools, generates a handler, and registers it. No restart needed.
 


### PR DESCRIPTION
## Description

Document an optional, manually invoked command for installing Parallel Search through mcptoon's existing URL-based MCP server flow. The endpoint requires no account or API key.

Parallel Search is not bundled or selected by default. When a user explicitly installs and uses it, user-provided search objectives, search queries, and requested URLs are sent to Parallel.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Changes

- Add `mcptoon install parallel-search --url https://search.parallel.ai/mcp` alongside the existing one-command install examples.
- State that the optional endpoint needs no account or API key.
- Disclose that user-provided search objectives, search queries, and requested URLs are sent to Parallel when the server is explicitly used.

## Testing

```bash
git diff --check
```

Also verified that `README.md` is the only changed path, the existing Brave Search example remains present, and the Parallel command and disclosure each appear exactly once.

## Checklist

- [x] My code follows the project style (zero third-party deps, type hints, docstrings)
- [ ] I have added tests for my changes
- [x] All applicable checks pass (`git diff --check`)
- [x] I have updated the documentation if needed
- [x] My changes are licensed under Apache 2.0

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.