### PR TITLE
docs: AGENTS.md agent rules + ecosystem ledger + README cost hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md — rules for AI agents working on mcptoon
+
+Any AI agent (Codex, Claude Code, Cursor, DSH, ...) writing code, docs, or cutting
+releases in this repo follows the rules on this page. They exist because mcptoon is
+now carried by external automation: numtide/llm-agents.nix packages this project and
+an official bot auto-bumps it on every PyPI release. A careless release breaks that
+channel; these rules keep it clean. Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Hard rules
+
+1. **Zero dependencies, always.** The `dependencies` field in `pyproject.toml` stays
+   empty. Standard library only. CI enforces this via `scripts/check_zero_deps.py` —
+   treat a red zero-deps job as a broken build, not a suggestion.
+2. **Tests gate every change.** New behavior ships with tests in `tests/`. Run
+   `python -m pytest tests/` and paste the real green output before claiming done.
+3. **Windows is a first-class target.** Anything touching paths, subprocess, or npx
+   must work on Windows; the CI matrix runs it on every PR.
+4. **Conventional Commits** for every commit (`feat:`, `fix:`, `docs:`, `test:`, `chore:`).
+
+## Release discipline
+
+A release is complete only when all five land together:
+
+1. version bumped in `pyproject.toml`
+2. `CHANGELOG.md` entry written for the new version
+3. full test suite green
+4. git tag `vX.Y.Z` pushed
+5. PyPI publish green (`.github/workflows/publish.yml`)
+
+The numtide bot turns PyPI releases into Nix bump PRs automatically. A version that
+exists on main but not on PyPI (or the reverse) leaves a broken bump in that channel.
+Breaking changes must land as deprecation warnings one minor version before removal.
+
+## Ecosystem channel ledger
+
+What mcptoon has earned externally, and the standing obligation each one creates:
+
+| Channel | Standing | Our obligation |
+|---|---|---|
+| numtide/llm-agents.nix | S-tier: packaged; bot auto-follows since init PR #7839 (zimbatm) | Release discipline above; after each release, confirm the bot PR merged |
+| PyPI | every release | publish workflow green before announcing |
+| MCP Registry (`server.json`) | listed | keep `server.json` in sync when commands/flags change |
+| apify/mcpc client comparison | listed in comparison table | none — leave the table alone |
+| awesome-mcp-clients PR #283 | pending | do not nag maintainers until ≥500 stars |
+| striki18/benchmark | third-party benchmark harness running mcptoon | external repo — read for intel, do not touch |
+
+Auto-crawler listings (topic indexes, news aggregators) are noise: never report them
+as traction. When reporting ecosystem progress, always pair listing counts with the
+real adoption number — PyPI downloads (https://pypistats.org/api/packages/mcptoon).
+
+## Where the older rules live (pointers — single source of truth, do not duplicate)
+
+- Dev workflow, code style, project structure → [CONTRIBUTING.md](CONTRIBUTING.md)
+- Architecture, the three core commands, token benchmarks → [DEVELOPERS.md](DEVELOPERS.md)
+- What to build next and why → [ROADMAP.md](ROADMAP.md)
+- Competitive landscape and positioning → [competitive-intel-mcp-manager-tools.md](competitive-intel-mcp-manager-tools.md)
+- Release history → [CHANGELOG.md](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@
 
 [中文文档](README.zh-CN.md) · [Developer docs](DEVELOPERS.md) · [Changelog](CHANGELOG.md) · [Report an issue](https://github.com/activeing123/mcptoon/issues)
 
+> 💸 **The hidden bill, re-charged every session.** A 255-tool / 50-server setup costs
+> **71,929 tokens** just to list the tools — re-payed in full every single session
+> (~**$6.5/month** for a daily user at $3/M input tokens, before any tool call).
+> mcptoon lists the same tools in **123 tokens**. Same tools, same agents, smaller bill.
+
 ## ⚡ 3 steps, any OS — no configuration
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,11 @@
 | 渠道 | 状态 | 地址 |
 |------|------|------|
 | GitHub | ✅ v0.7.2，CI 全绿 | github.com/activeing123/mcptoon |
-| PyPI | ✅ 0.7.2 | pypi.org/project/mcptoon/0.7.2 |
+| PyPI | ✅ 0.7.2（pypistats 全量 2014 次 @2026-09-02——收录≠采用，以此为准绳） | pypi.org/project/mcptoon/0.7.2 |
+| numtide/llm-agents.nix | ✅ 官方打包（init PR#7839 by zimbatm；bot 自动跟版至 0.7.2）→ 发版纪律见 AGENTS.md | github.com/numtide/llm-agents.nix |
+| apify/mcpc 客户端对比表 | ✅ 收录（PR#370 by 联合创始人 jancurn） | github.com/apify/mcpc |
+| striki18/benchmark | ✅ 代码级集成：其 harness 注册 mcptoon 为压缩工具（上游调用有已知 bug，见 competitive-intel §F） | github.com/striki18/benchmark |
+| SimonSchubert/LinuxCommandLibrary | ✅ 收录 mcptoon.md 命令手册（1967★ App，2M+ 下载） | github.com/SimonSchubert/LinuxCommandLibrary |
 | MCP Registry | ✅ 收录 v0.7.0（0.7.1 元数据更新：用户指示过几天再更） | registry.modelcontextprotocol.io |
 | Glama | ✅ 收录 + Dockerfile 构建检查通过（python -m 方案，见 .scratch 存档） | glama.ai/mcp/servers/activeing123/mcptoon |
 | awesome-mcp-servers | 🟡 PR #12910 就绪等合（listed+badge 双条件已满足） | github.com/punkpeye/awesome-mcp-servers/pull/12910 |

--- a/competitive-intel-mcp-manager-tools.md
+++ b/competitive-intel-mcp-manager-tools.md
@@ -55,3 +55,30 @@
 
 - github_api engine failed in all runs → run targeted GitHub lookups for star counts on: shane-kerval mcp-client-agent, theshadow27/mcp-cli, lastmile-ai/mcp-agent, rinadelph/Agent-MCP, mikusnuz/agent-link-mcp, Atlassian mcp-compressor.
 - Deep-read Requesty gateway comparison + Peliqan landscape for the enterprise vendor shortlist (LiteLLM/Portkey-class players were NOT directly surfaced by these queries).
+
+## F. Token-compressor peers — striki18/benchmark harness (verified 2026-09-02)
+
+`striki18/benchmark` (created 2026-08-21, 0★, single-maintainer) runs a tool-by-tool
+token-compression benchmark under `benchmark_harness/tools/`. mcptoon is registered
+there (`mcptoon_tool.py`) — third parties already treat mcptoon as a compressor. The
+same directory enumerates our head-to-head compressor peers; treat this list as the
+feature-comparison set for `docs/comparison.md`:
+
+| Peer | In harness as | What it is |
+|---|---|---|
+| microsoft/llmlingua | `llmlingua_tool.py` | prompt compression (LLM-based) |
+| dytok | `dytok_tool.py` | tokenizer/TOON-style encoder |
+| headroom | `headroom_tool.py` | context trimming |
+| rtk | `rtk_tool.py` | repo/knowledge tokenizer |
+| less_tokens (py + sdk) | `less_tokens_*_tool.py` | text compression utility |
+| mintoken (cli + extension) | `mintoken_*_tool.py` | minimal-token CLI tooling |
+| tokenbank | `tokenbank_tool.py` | token accounting/banking |
+| selective-context | `selective_context_tool.py` | selective context pruning |
+| context_packer | `context_packer_tool.py` | context packing |
+| claude_supertool | `claude_supertool_tool.py` | Claude-focused context tool |
+
+Known harness bug (upstream, 2026-09-02): `mcptoon_tool.py.compress()` invokes
+`mcptoon manifest --slim` without feeding content via stdin/args, so its mcptoon
+numbers measure a bare command, not compression of the sample. If a future decision
+allows upstream PRs, that fix is the highest-value contribution — until then quote
+no benchmark numbers sourced from this harness.


### PR DESCRIPTION
## What

Four doc changes that turn the 2026-09 ecosystem audit into standing rules:

1. **`AGENTS.md` (new)** — the rules any AI agent working in this repo must follow:
   - Hard rules (zero-dep / tests / Windows / conventional commits) — all already enforced by CI or existing convention; AGENTS.md makes them visible to every agent that opens the repo.
   - **Release discipline** tied to the numtide obligation: release = version bump + CHANGELOG + green tests + tag + PyPI publish, together. The numtide/llm-agents.nix bot (init PR #7839 by zimbatm, auto-bumps since) turns PyPI releases into Nix PRs; a half-done release leaves a broken bump in that channel.
   - **Ecosystem channel ledger** — S/A/C/D standing per channel and the standing obligation each creates (incl. "crawler listings are noise, never report them as traction; always pair listings with pypistats downloads").
2. **`competitive-intel-mcp-manager-tools.md` §F** — verified peer list from striki18/benchmark harness (llmlingua, dytok, headroom, rtk, less_tokens, mintoken, tokenbank, selective-context, context_packer, claude_supertool) + documents the known upstream bug (its mcptoon_tool.py calls `manifest --slim` without feeding content, so harness numbers for mcptoon are void until fixed).
3. **`README.md`** — cost hook added above the quickstart (255 tools / 50 servers = 71,929 tokens re-charged every session ≈ $6.5/month at $3/M input tokens vs 123 tokens with mcptoon). Onboarding hook stays untouched.
4. **`ROADMAP.md`** — channel table now records numtide / apify/mcpc / striki18 / LinuxCommandLibrary integrations + the pypistats baseline (2014 downloads @ 2026-09-02) as the adoption yardstick.

## Verification

- striki18 repo name verified via GitHub code search (it is `striki18`, not `strik18`).
- numtide PR history verified via API: #7839 init by zimbatm + 12 bot bump PRs (0.1.0 → 0.7.2), all merged.
- apify/mcpc README mentions mcptoon 4x (comparison table confirmed).
- pypistats overall (mirrors=false): 2,014 downloads.
- Docs-only change; CI will run the full matrix on this PR.
